### PR TITLE
Add Vultisig ecosystem (58 repos)

### DIFF
--- a/migrations/2026-08-20T120000_add_vultisig_ecosystem
+++ b/migrations/2026-08-20T120000_add_vultisig_ecosystem
@@ -1,0 +1,112 @@
+-- Add Vultisig, a seedless multi-chain wallet secured by MPC threshold signatures (vultisig.com)
+-- Repos are the original (non-fork) public repos of the github.com/vultisig org, minus vultisig/.github.
+-- Forks (wallet-core, tss-lib, cait-sith, monero-oxide, silent-shard-dkls23-ll, etc.) are excluded.
+-- The 13 vultisig/* repos already in the taxonomy keep their existing chain mappings; this
+-- migration groups them under a single Vultisig ecosystem alongside the 44 that were missing.
+ecoadd Vultisig
+
+-- Category parents, matching how other multi-chain wallets are connected (Trust Wallet, Phantom).
+ecocon "Wallet (Category)" Vultisig
+ecocon "Multichain Infrastructure" Vultisig
+
+-- Chain parents. This is exactly the set of chain ecosystems that already attribute at least one
+-- vultisig/* repo today, so no new chain claims are introduced by this migration.
+ecocon Bitcoin Vultisig
+ecocon Ethereum Vultisig
+ecocon Base Vultisig
+ecocon Solana Vultisig
+ecocon Sui Vultisig
+ecocon Tron Vultisig
+ecocon XRP Vultisig
+ecocon THORChain Vultisig
+ecocon "Cosmos Hub" Vultisig
+ecocon "Cosmos Network Stack" Vultisig
+ecocon TON Vultisig
+ecocon "Polkadot Network" Vultisig
+ecocon Zcash Vultisig
+ecocon Monero Vultisig
+
+-- Client applications
+repadd Vultisig https://github.com/vultisig/vultisig-ios #wallet
+repadd Vultisig https://github.com/vultisig/vultisig-android #wallet
+repadd Vultisig https://github.com/vultisig/vultisig-windows #wallet
+repadd Vultisig https://github.com/vultisig/vultisig-web #wallet
+repadd Vultisig https://github.com/vultisig/vultisig-cli #wallet
+repadd Vultisig https://github.com/vultisig/vulticonnect #wallet
+repadd Vultisig https://github.com/vultisig/vultisig-sdk-old #wallet
+
+-- SDKs, libraries and shared schemas
+repadd Vultisig https://github.com/vultisig/vultisig-sdk #sdk
+repadd Vultisig https://github.com/vultisig/vultisig-go #sdk
+repadd Vultisig https://github.com/vultisig/vultisig-wasm #sdk
+repadd Vultisig https://github.com/vultisig/go-wrappers #library
+repadd Vultisig https://github.com/vultisig/walletcore-spm #library
+repadd Vultisig https://github.com/vultisig/WalletCoreSwiftProtobuf #library
+repadd Vultisig https://github.com/vultisig/commondata #library
+
+-- Threshold signing (MPC) implementations and research
+repadd Vultisig https://github.com/vultisig/mobile-tss-lib #protocol
+repadd Vultisig https://github.com/vultisig/dkls-android #protocol
+repadd Vultisig https://github.com/vultisig/frosty-lib #protocol
+repadd Vultisig https://github.com/vultisig/frost-zcash #protocol
+repadd Vultisig https://github.com/vultisig/tss-director #protocol
+repadd Vultisig https://github.com/vultisig/tss-lib-upgrade #protocol
+repadd Vultisig https://github.com/vultisig/tss-research #protocol
+repadd Vultisig https://github.com/vultisig/test-dkls #developer-tool
+
+-- Backend services
+repadd Vultisig https://github.com/vultisig/vultiserver #protocol
+repadd Vultisig https://github.com/vultisig/vultisig-relay #protocol
+repadd Vultisig https://github.com/vultisig/verifier #protocol
+repadd Vultisig https://github.com/vultisig/notification
+repadd Vultisig https://github.com/vultisig/airdrop-registry
+repadd Vultisig https://github.com/vultisig/defi-circle
+repadd Vultisig https://github.com/vultisig/card-backend
+repadd Vultisig https://github.com/vultisig/referral-back
+
+-- Plugin / app platform
+repadd Vultisig https://github.com/vultisig/plugin
+repadd Vultisig https://github.com/vultisig/plugin-agent
+repadd Vultisig https://github.com/vultisig/plugin-tests #developer-tool
+repadd Vultisig https://github.com/vultisig/app-developer
+repadd Vultisig https://github.com/vultisig/app-recurring
+repadd Vultisig https://github.com/vultisig/app-marketplace
+repadd Vultisig https://github.com/vultisig/feeplugin
+repadd Vultisig https://github.com/vultisig/copytrading
+repadd Vultisig https://github.com/vultisig/recipes
+repadd Vultisig https://github.com/vultisig/vcli #developer-tool
+
+-- Smart contracts
+repadd Vultisig https://github.com/vultisig/vultisig-contract #contracts
+
+-- Developer tooling
+repadd Vultisig https://github.com/vultisig/community-tools #developer-tool
+repadd Vultisig https://github.com/vultisig/vultisig-toolbox #developer-tool
+repadd Vultisig https://github.com/vultisig/android-automation #developer-tool
+repadd Vultisig https://github.com/vultisig/analytics-dashboard #developer-tool
+repadd Vultisig https://github.com/vultisig/homebrew-tap #developer-tool
+
+-- Documentation
+repadd Vultisig https://github.com/vultisig/docs #documentation
+repadd Vultisig https://github.com/vultisig/plugins-docs #documentation
+repadd Vultisig https://github.com/vultisig/docs-plugins #documentation
+repadd Vultisig https://github.com/vultisig/developer-portal #documentation
+
+-- Websites and brand assets
+repadd Vultisig https://github.com/vultisig/website-prod #website
+repadd Vultisig https://github.com/vultisig/vultisig.github.io #website
+repadd Vultisig https://github.com/vultisig/launch-web #website
+repadd Vultisig https://github.com/vultisig/referral-front #website
+repadd Vultisig https://github.com/vultisig/vultiphone #website
+repadd Vultisig https://github.com/vultisig/Branding
+repadd Vultisig https://github.com/vultisig/vultichain
+
+-- LimeChain/vultisig-mono is Vultisig product code ("Vultisig verification and plugin servers"),
+-- written by LimeChain under contract. That engagement ended: the last commit is 2025-05-14 and
+-- LimeChain no longer contributes. It is currently in the taxonomy twice under two casings, and
+-- the Limechain membership rolls the activity up under Polkadot Network.
+-- Merge the case-duplicate into the canonical GitHub casing, drop the stale Limechain membership,
+-- and attribute the repo to Vultisig. The Ethereum membership is left untouched.
+repmov https://github.com/limechain/vultisig-mono https://github.com/LimeChain/vultisig-mono
+reprem Limechain https://github.com/LimeChain/vultisig-mono
+repadd Vultisig https://github.com/LimeChain/vultisig-mono #protocol


### PR DESCRIPTION
Vultisig is an open-source, seedless multi-chain wallet secured by MPC threshold signatures (DKLS23). It ships on iOS, Android, Windows/macOS/Linux desktop, and as a Chrome extension. Website: https://vultisig.com · Org: https://github.com/vultisig

There is currently no Vultisig ecosystem in the taxonomy. 13 of the org's 57 non-fork public repos are mapped, scattered across Bitcoin / Ethereum / Solana / Sui / Tron / XRP / THORChain / Cosmos / TON / Polkadot / Zcash / Monero / Base and the Wallet category. The other 44 are not in the dataset at all — including the MPC libraries (`mobile-tss-lib`, `dkls-android`, `frost-zcash`), the relay and verifier servers, and the whole plugin platform.

This migration adds a single `Vultisig` ecosystem and maps all 58 repos to it.

A few notes on the choices I made, since they are the parts worth arguing with.

**Chain connections.** Vultisig supports 38 chains, but I connected the ecosystem only to the 14 chain ecosystems that already attribute at least one `vultisig/*` repo today. `ecocon` makes every repo in the child count toward the parent, so connecting all 38 would spray the same 58 repos across 38 chains' numbers. This PR therefore introduces no chain that was not already there. Happy to trim further if even 14 is too broad.

**`Wallet (Category)` and `Multichain Infrastructure`.** Following how Trust Wallet and Phantom are connected.

**Forks excluded.** 15 forks (`wallet-core`, `tss-lib`, `cosmos-sdk`, `cait-sith`, `monero-oxide`, etc.) are left out, matching the convention in the recent Tempo migration.

**Archived repos included.** Three archived repos are in the list — `vulticonnect` (the original browser extension), `plugin`, and `vultiphone`. They carry real commit history and the taxonomy is historical, so I kept them. The Tempo migration excluded archived repos, but Tempo is a brand-new ecosystem with no history to lose. If your convention is to exclude them regardless, say so and I will drop the three lines.

**`LimeChain/vultisig-mono`.** This is the one part of the migration that removes existing data, so here is the full reasoning.

The repo is Vultisig product code. Its own GitHub description is "Vultisig verification and plugin servers". LimeChain wrote it under contract for Vultisig. That engagement has ended and LimeChain no longer contributes: the last commit is `b9a59fd`, dated 2025-05-14, 15 months ago. Verified against the API — `repos/LimeChain/vultisig-mono` reports `pushed_at: 2025-05-14T07:38:50Z`, `archived: false`, `fork: false`, and a single contributor (`radkomih`, 4 commits).

Today it sits in the taxonomy twice, under two casings of the same GitHub URL:

- `https://github.com/LimeChain/vultisig-mono` → `Limechain`, added by `2024-12-31T235959_mutations:1432`
- `https://github.com/limechain/vultisig-mono` → `Ethereum`, added by `2025-12-07T174838_add_ethereum_repos:366`

GitHub org names are case-insensitive, so that is one repository counted as two.

The `Limechain` ecosystem is connected under `Polkadot Network`. Net effect: a dormant Vultisig backend currently reports as LimeChain developer activity inside Polkadot's numbers, which is wrong on both counts.

There was already an attempt to remove it. `2025-05-26T092415_mutations:19294` runs `reprem Limechain https://github.com/LimeChain/vultisig-plugins-marketplace`. That was the repo's old name — the URL 301-redirects to `vultisig-mono` — so the removal targeted a URL that is not in the dataset and the mapping survived under the new name. This migration targets the URL that is actually there.

Three lines at the end of the file:

```
repmov https://github.com/limechain/vultisig-mono https://github.com/LimeChain/vultisig-mono
reprem Limechain https://github.com/LimeChain/vultisig-mono
repadd Vultisig https://github.com/LimeChain/vultisig-mono #protocol
```

Merge the case-duplicate into GitHub's canonical casing, drop the stale `Limechain` membership, attribute the repo to `Vultisig`. The `Ethereum` membership from the lowercase record rides along on the merge and is left untouched — that one is a chain mapping, not an authorship claim. After the migration, `Limechain` goes from 305 to 304 repos and `vultisig-mono` appears exactly once, under the canonical URL.

If you would rather review the removal separately from the ecosystem addition, I am happy to split it into its own PR.

## receipts

Run locally against the full taxonomy from genesis — the same two commands `pull_request_check.yml` runs:

```
$ ./run.sh test
28 passed in 0.05s

$ ./run.sh validate
806    Migrations
7671   Ecosystems
752933 Repos
1109   Tags
(exit 0)
```

Baseline before the change was 805 / 7670 / 752890. Net +43 repos: 58 `repadd` lines, 14 of which were already present, minus the case-duplicate the `repmov` merges away.

As a check that the clean pass is not vacuous, appending a deliberately wrong `ecocon Sei Vultisig` (the dataset name is `Sei Network`) and a `reprem` against the now-nonexistent lowercase URL produces:

```
migrations/2026-08-20T120000_add_vultisig_ecosystem:113: InvalidParentEcosystem
migrations/2026-08-20T120000_add_vultisig_ecosystem:114: InvalidRepo
exit 1
```

The second error is also the receipt that the case-duplicate is genuinely gone after the merge.
